### PR TITLE
Alfred auto teleportation when inventory full

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -56,10 +56,6 @@ local function main_pulse()
         return
     end
 
-    if orbwalker.get_orb_mode() ~= 3 then
-        orbwalker.set_clear_toggle(true);
-    end
-
     task_manager.execute_tasks()
 end
 

--- a/status.lua
+++ b/status.lua
@@ -1,0 +1,75 @@
+function task.Execute()
+    local local_player = get_local_player()
+    if not local_player then
+        return
+    end
+
+    local restock_trigger = false
+    local status = all_task_done()
+    if status.complete then
+        utils.reset_all_task()
+        task.teleport_trigger_time = nil
+        tracker.manual_trigger = false
+        tracker.trigger_tasks = false
+        tracker.all_task_done = true
+        if settings.allow_external and tracker.external_trigger then
+            tracker.external_trigger = false
+            tracker.external_caller = nil
+            if tracker.external_trigger_callback then
+                pcall(tracker.external_trigger_callback)
+                tracker.external_trigger_callback = nil
+            end
+        end
+    end
+
+    if tracker.restock_count > 0 then
+        restock_trigger = true
+    end
+
+    if tracker.timeout then
+        task.status = status_enum['TIMEOUT']
+    elseif ((settings.allow_external and tracker.external_trigger) or
+        tracker.inventory_full or tracker.manual_trigger) or restock_trigger
+    then
+        if settings.get_export_keybind_state() and task.status ~= status_enum['WAITING'] then
+            utils.export_inventory_info()
+        end
+        
+        -- Add teleport trigger for manual activation
+        if tracker.manual_trigger then
+            tracker.teleport = true
+        end
+        
+        -- Check and set task flags based on settings/parameters
+        if settings.stash_all_socketables and #get_local_player():get_socketable_items() > 0 then
+            tracker.stash_socketables = true
+        end
+        if settings.stash_extra_materials then
+            if #get_local_player():get_consumable_items() > 0 then
+                tracker.stash_boss_materials = true
+            end
+            if #get_local_player():get_dungeon_key_items() > 0 then
+                tracker.stash_compasses = true
+            end
+        end
+        
+        -- Set repair flag if enabled in settings
+        if settings.auto_repair then
+            tracker.repair_count = 1  -- This will trigger repair task
+        end
+        
+        -- Set sell/salvage flags if enabled
+        if settings.auto_sell then
+            tracker.sell_count = 1    -- This will trigger sell task
+        end
+        if settings.auto_salvage then
+            tracker.salvage_count = 1 -- This will trigger salvage task
+        end
+
+        tracker.trigger_tasks = true
+        task.status = status_enum['WAITING']
+    else
+        task.status = status_enum['IDLE']
+        tracker.last_task = task.name
+    end
+end 

--- a/tasks/inventory_teleport.lua
+++ b/tasks/inventory_teleport.lua
@@ -1,0 +1,114 @@
+local plugin_label = 'alfred_the_butler'
+
+local utils = require 'core.utils'
+local settings = require 'core.settings'
+local tracker = require 'core.tracker'
+local explorerlite = require 'core.explorerlite'
+local base_task = require 'tasks.base'
+
+local task = base_task.new_task()
+local status_enum = {
+    IDLE = 'Idle',
+    EXECUTE = 'Teleporting',
+    WAITING = 'Waiting for teleport cooldown',
+    FAILED = 'Failed to teleport'
+}
+
+-- Time to wait between teleport attempts
+local TELEPORT_COOLDOWN = 2
+local last_teleport_time = 0
+
+local extension = {}
+
+function extension.get_npc()
+    return nil  -- No NPC needed for this task
+end
+
+function extension.move()
+    -- No movement needed
+end
+
+function extension.interact()
+    -- No interaction needed
+end
+
+function extension.execute()
+    local current_time = get_time_since_inject()
+    
+    -- Check if we can teleport again
+    if current_time - last_teleport_time < TELEPORT_COOLDOWN then
+        return
+    end
+    
+    -- Press 'T' key to teleport
+    send_key('T')
+    last_teleport_time = current_time
+    
+    -- Trigger other tasks
+    tracker.trigger_tasks = true
+    tracker.teleport = true
+end
+
+function extension.reset()
+    -- No reset needed
+end
+
+function extension.is_done()
+    return tracker.trigger_tasks
+end
+
+function extension.done()
+    -- Reset flags when done
+    tracker.inventory_full = false
+end
+
+function extension.failed()
+    -- Handle failure
+    tracker.teleport_failed = true
+end
+
+function extension.is_in_vendor_screen()
+    return false
+end
+
+-- Check if inventory is full
+local function is_inventory_full()
+    local local_player = get_local_player()
+    if not local_player then return false end
+    
+    local inventory = local_player:get_inventory_items()
+    -- Assuming 33 is max inventory size
+    return #inventory >= 33
+end
+
+task.name = 'inventory_teleport'
+task.extension = extension
+task.status_enum = status_enum
+task.max_retries = 3
+
+task.shouldExecute = function()
+    if tracker.trigger_tasks == false then
+        task.retry = 0
+    end
+    
+    -- Execute if inventory is full and we're not already handling it
+    if is_inventory_full() and not tracker.trigger_tasks then
+        tracker.inventory_full = true
+        return true
+    end
+    
+    return false
+end
+
+-- Override the base Execute function
+task.baseExecute = task.Execute
+task.Execute = function()
+    if not tracker.trigger_tasks then
+        task.status = status_enum['EXECUTE']
+        task.extension.execute()
+    else
+        task.baseExecute()
+    end
+end
+
+return task 


### PR DESCRIPTION
# Refactor & Feature Updates: Inventory Management & Teleport Fixes

## ✨ Refactor (main): Remove Unnecessary Orbwalker Auto-Enable
- **Removed automatic orbwalker activation** as it was not required for core functionality.  
- **Prevents unintended activation** when the script is running.
- **Fixed keybind functionality, allowing manual activation. (Can now test manual activation with keybind) Players will now teleport to Cerrigar, execute their tasks, and return to the portal automatically.

## 🚀 Feature (status): Add Auto-Trigger Functionality for Inventory Management  
- **Implemented automatic task triggering** for:
  - Repair  
  - Sell  
  - Salvage  
- **Added stash functionality** for socketables and materials.  
- **Fixed manual trigger teleport functionality.**  
- **Updated task completion handling** and external trigger management.  

## ⚡ Feature (inventory): Add Automatic Teleport on Inventory Full  
- **Implemented inventory full detection** with automatic teleport trigger.  
- **Added cooldown system** for teleport attempts.  
- **Implemented task status tracking** and failure handling.  
- **Integrated teleport system with core task management.**  

## 🔹 Important Notes  
- **Teleport is currently bound to `T`.**  
  - Players must set **Cerrigar as their favorite city** for the teleport function to work correctly.  

### 🛠 Manual Testing  
1. **Enable the keybind** in settings.  
2. **Set to manual mode.**  
3. Press the keybind to teleport to **Cerrigar**, execute tasks, and return to the portal.  

### ⚙️ Auto Functionality  
- When the **inventory is full**, teleport will **automatically trigger** without manual input. 
